### PR TITLE
generated field

### DIFF
--- a/apps/production/src/scenes/notice/components/field.js
+++ b/apps/production/src/scenes/notice/components/field.js
@@ -164,9 +164,8 @@ export default class AbstractField extends React.Component {
     tooltipOpen: false
   };
   render() {
-    const { label, type, name, description, ...rest } = this.props;
-
-    let desc = description || "En attente de description" + "\n";
+    const { label, type, name, description, generated, ...rest } = this.props;
+    let desc = description || "En attente de description";
 
     let Comp = <div />;
     if (type === "String") {
@@ -192,6 +191,7 @@ export default class AbstractField extends React.Component {
           }
         >
           {desc}
+          {generated ? <div><br />Ce champ est généré et n'est pas modifiable.</div>: ""}
         </Tooltip>
         {Comp}
       </div>


### PR DESCRIPTION
CF: https://trello.com/c/NJAlslKq/320-ajouter-ce-champ-est-g%C3%A9n%C3%A9r%C3%A9-dans-la-tooltip-de-description-des-champs-g%C3%A9n%C3%A9r%C3%A9s-sur-la-notice-d%C3%A9velop%C3%A9e

<img width="709" alt="capture d ecran 2019-01-09 a 14 03 37" src="https://user-images.githubusercontent.com/1575946/50901099-7ae2d480-1417-11e9-8ce9-98a92fdf2f6b.png">
