### PR TITLE
fix h5

### DIFF
--- a/apps/consultation/src/scenes/notice/components/title.css
+++ b/apps/consultation/src/scenes/notice/components/title.css
@@ -1,6 +1,0 @@
-.title h2 {
-  color: #19414c;
-  font-weight: 700;
-  font-size: 26px;
-  margin-bottom: 20px;
-}

--- a/apps/consultation/src/scenes/notice/components/title.js
+++ b/apps/consultation/src/scenes/notice/components/title.js
@@ -1,16 +1,13 @@
 import React from "react";
-import "./title.css";
 
 class Title extends React.Component {
   render() {
-    const hasVisibleFields = !!this.props.fields.filter(
-      f =>
-        Array.isArray(this.props.notice[f])
-          ? this.props.notice[f].length
-          : this.props.notice[f]
+    const { fields, notice, content, small } = this.props;
+    const hasVisibleFields = !!fields.filter(f =>
+      Array.isArray(notice[f]) ? notice[f].length : notice[f]
     ).length;
     if (hasVisibleFields) {
-      return <h2>{this.props.content}</h2>;
+      return small ? <h2 className="small">{content}</h2> : <h2>{content}</h2>;
     }
     return <div />;
   }

--- a/apps/consultation/src/scenes/notice/index.css
+++ b/apps/consultation/src/scenes/notice/index.css
@@ -30,6 +30,10 @@
   margin-bottom: 20px;
 }
 
+.notice .notice-details h2.small {
+  font-size: 22px;
+}
+
 .notice .notice-btn {
   text-decoration: none;
   background-color: #377d87;

--- a/apps/consultation/src/scenes/notice/memoire.js
+++ b/apps/consultation/src/scenes/notice/memoire.js
@@ -147,7 +147,7 @@ class Memoire extends React.Component {
                 />
                 <Title
                   content="Localisation"
-                  h5={true}
+                  small={true}
                   notice={notice}
                   fields={["LOCA", "INSEE", "ADRESSE", "MCGEO"]}
                 />
@@ -157,7 +157,7 @@ class Memoire extends React.Component {
                 <Field title="Nom géographique" content={notice.MCGEO} />
                 <Title
                   content="Identification"
-                  h5={true}
+                  small={true}
                   notice={notice}
                   fields={[
                     "EDIF",
@@ -203,7 +203,7 @@ class Memoire extends React.Component {
                 />
                 <Title
                   content="Références des documents reproduits"
-                  h5={true}
+                  small={true}
                   notice={notice}
                   fields={["AUTOR", "TIREDE", "LIEUCOR", "COTECOR", "AUTG"]}
                 />
@@ -274,7 +274,7 @@ class Memoire extends React.Component {
                 />
                 <Title
                   content="Éléments d’identification"
-                  h5={true}
+                  small={true}
                   notice={notice}
                   fields={[
                     "TYPDOC",
@@ -339,7 +339,7 @@ class Memoire extends React.Component {
                 <Field title="Échelle du graphique" content={notice.ECH} />
                 <Title
                   content="Description technique du phototype"
-                  h5={true}
+                  small={true}
                   notice={notice}
                   fields={[
                     "TECH",
@@ -376,7 +376,7 @@ class Memoire extends React.Component {
                 <Field title="Orientation du phototype" content={notice.SENS} />
                 <Title
                   content="Datation et événements liés à l’image"
-                  h5={true}
+                  small={true}
                   notice={notice}
                   fields={[
                     "DATPV",


### PR DESCRIPTION
En fait je pense que h5 servait à faire des titres plus petit pour éviter que ça fasse ça : 

<img width="908" alt="capture d ecran 2019-01-15 a 14 19 25" src="https://user-images.githubusercontent.com/1575946/51183110-98f57c80-18d0-11e9-8a2f-4c1ee530e4ed.png">

Mais c'était pourri d'appeler ça h5 en plus yavait du code mal fichu. J'ai remplacé et corrigé un peu et ça donne ça : 

<img width="884" alt="capture d ecran 2019-01-15 a 14 20 34" src="https://user-images.githubusercontent.com/1575946/51183174-bfb3b300-18d0-11e9-98b9-3ab123fc82d5.png">
