### PR TITLE
links in notices

### DIFF
--- a/apps/consultation/src/scenes/notice/joconde.js
+++ b/apps/consultation/src/scenes/notice/joconde.js
@@ -68,6 +68,44 @@ class Joconde extends React.Component {
     }
   }
 
+  // Display a list of links to authors
+  author() {
+    const author = this.state.notice.AUTR;
+    if (!author) {
+      return <div />;
+    }
+    // Split authors and create links to both single author and all authors.
+    if (author.match(/;/)) {
+      const links = author
+        .split(";")
+        .map(a => a.trim())
+        .map(a => <a href={`/search/list?auteur="${a}, ${author}"`}>{a}</a>);
+      return <div>{links.reduce((p, c) => [p, " ; ", c])}</div>;
+    }
+    return <a href={`/search/list?auteur="${author}"`}>{author}</a>;
+  }
+
+  // Display a list of links to domains
+  domain() {
+    const domain = this.state.notice.DOMN;
+    if (!domain) {
+      return <div />;
+    }
+    // Create multiple links if multiple domains.
+    if (Array.isArray(domain)) {
+      const links = domain.map(d => (
+        <a href={`/search/list?domn="${d}"`}>{d}</a>
+      ));
+      return <div>{links.reduce((p, c) => [p, ", ", c])}</div>;
+    }
+    return <a href={`/search/list?domn="${domain}"`}>{domain}</a>;
+  }
+
+  period() {
+    const period = this.state.notice.PERI;
+    return period && <a href={`/search/list?periode="${period}"`}>{period}</a>;
+  }
+
   render() {
     if (this.state.loading) {
       return <Loader />;
@@ -145,14 +183,14 @@ class Joconde extends React.Component {
                 />
                 <Field
                   title="Domaine (catégorie du bien)"
-                  content={notice.DOMN}
+                  content={this.domain()}
                 />
                 <Field title="Dénomination du bien" content={notice.DENO} />
                 <Field title="Appellation" content={notice.APPL} />
                 <Field title="Titre" content={notice.TITR} />
                 <Field
                   title="Auteur / exécutant / collecteur"
-                  content={notice.AUTR}
+                  content={this.author()}
                 />
                 <Field
                   title="Précisions / auteur / exécutant / collecteur"
@@ -162,7 +200,7 @@ class Joconde extends React.Component {
                 <Field title="Anciennes attributions" content={notice.ATTR} />
                 <Field
                   title="Période de création / exécution"
-                  content={notice.PERI}
+                  content={this.period()}
                 />
                 <Field
                   title="Millésime de création / exécution"

--- a/apps/consultation/src/scenes/notice/joconde.js
+++ b/apps/consultation/src/scenes/notice/joconde.js
@@ -79,7 +79,7 @@ class Joconde extends React.Component {
       const links = author
         .split(";")
         .map(a => a.trim())
-        .map(a => <a href={`/search/list?auteur="${a}, ${author}"`}>{a}</a>)
+        .map(a => <a href={`/search/list?auteur="${a}, ${author}"`} key={a}>{a}</a>)
         .reduce((p, c) => [p, " ; ", c]);
       return <React.Fragment>{links}</React.Fragment>;
     }
@@ -95,7 +95,7 @@ class Joconde extends React.Component {
     // Create multiple links if multiple domains.
     if (Array.isArray(domain)) {
       const links = domain
-        .map(d => <a href={`/search/list?domn="${d}"`}>{d}</a>)
+        .map(d => <a href={`/search/list?domn="${d}"`} key={d}>{d}</a>)
         .reduce((p, c) => [p, ", ", c]);
       return <React.Fragment>{links}</React.Fragment>;
     }

--- a/apps/consultation/src/scenes/notice/joconde.js
+++ b/apps/consultation/src/scenes/notice/joconde.js
@@ -79,8 +79,9 @@ class Joconde extends React.Component {
       const links = author
         .split(";")
         .map(a => a.trim())
-        .map(a => <a href={`/search/list?auteur="${a}, ${author}"`}>{a}</a>);
-      return <div>{links.reduce((p, c) => [p, " ; ", c])}</div>;
+        .map(a => <a href={`/search/list?auteur="${a}, ${author}"`}>{a}</a>)
+        .reduce((p, c) => [p, " ; ", c]);
+      return <React.Fragment>{links}</React.Fragment>;
     }
     return <a href={`/search/list?auteur="${author}"`}>{author}</a>;
   }
@@ -93,10 +94,10 @@ class Joconde extends React.Component {
     }
     // Create multiple links if multiple domains.
     if (Array.isArray(domain)) {
-      const links = domain.map(d => (
-        <a href={`/search/list?domn="${d}"`}>{d}</a>
-      ));
-      return <div>{links.reduce((p, c) => [p, ", ", c])}</div>;
+      const links = domain
+        .map(d => <a href={`/search/list?domn="${d}"`}>{d}</a>)
+        .reduce((p, c) => [p, ", ", c]);
+      return <React.Fragment>{links}</React.Fragment>;
     }
     return <a href={`/search/list?domn="${domain}"`}>{domain}</a>;
   }


### PR DESCRIPTION
<img width="1169" alt="capture d ecran 2019-01-15 a 17 02 03" src="https://user-images.githubusercontent.com/1575946/51192743-89cdf900-18e7-11e9-880d-f59e3188fb10.png">


En fait ya un peu de code, donc j'ai dû créer des fonctions. C'est en partie du bricolage, mais pour moi ça apporte beaucoup de valeur et ça nous permet d'avancer sans attendre de validation et de nettoyage des données. Comme tout code, on peut le jeter quand on veut, c'est pas un pb.

L'idée c'est de permettre de rechercher sur les auteurs, les domaines et les périodes sans rien changer au modèle de données. quand il évoluera, on jette ce dont on n'a plus besoin.

Le côté "ça fait le taff" pour les auteurs c'est qu'on cherche à la fois sur l'auteur splité ET les auteurs mis bout à bout: 

```jsx
const links = author
        .split(";")
        .map(a => a.trim())
        .map(a => <a href={`/search/list?auteur="${a}, ${author}"`}>{a}</a>);
```

Le truc important c'est ça : 
```jsx
${a}, ${author}
```

En gros elle est là la bidouille. Mais du coup ça fait des résultats satisfaisants pour l'**utilisateur**.