### PR TITLE
memoire img is null

### DIFF
--- a/apps/production/src/scenes/search/components/MemoireCard.js
+++ b/apps/production/src/scenes/search/components/MemoireCard.js
@@ -5,7 +5,7 @@ import mh from "../../../assets/mh.png";
 
 export default ({ data }) => {
   let image = "";
-  if (data.IMG.indexOf("memoire") === 0) {
+  if (data.IMG && data.IMG.indexOf("memoire") === 0) {
     image = `${bucket_url}${data.IMG}`;
   } else if (data.IMG) {
     image = `${data.IMG}`;


### PR DESCRIPTION
La valeur de IMG est parfois `null`. C'est bizarre car je croyais que c'était forcément une chaine de caractère. en tout cas ce commit fixe ça : https://trello.com/c/7b6NWA7J/365-bug-recherche-http-productionpopculturegouvfr-recherche-avancee-memoireq5b05d5bcombinator5detq5b05d5bkey5drefq5b05d5boperator5d5 mais je ne comprends pas la source du PB...