### PR TITLE
faster navigation from topics

### DIFF
--- a/apps/consultation/src/components/TopicCard.js
+++ b/apps/consultation/src/components/TopicCard.js
@@ -10,7 +10,7 @@ class TopicCard extends React.Component {
       ...Object.entries(data).map(([k, v]) => ({ [k]: JSON.stringify(v) }))
     );
     const qsData = queryString.stringify(jsonData);
-    return `/search/mosaique?${qsData}`;
+    return `/search/mosaique?${qsData}&image=["oui"]`;
   }
 
   render() {


### PR DESCRIPTION
ça évite un double chargement (car le `toggle`) rajoute `image=["oui"]` après coup.