### PR TITLE
ignore null on image

### DIFF
--- a/apps/consultation/src/scenes/notice/utils.js
+++ b/apps/consultation/src/scenes/notice/utils.js
@@ -1,7 +1,7 @@
 import { bucket_url } from "../../config";
 
 export function findCollection(ref = "") {
-  if(typeof ref !== 'string') {
+  if (typeof ref !== "string") {
     return "";
   }
   const prefix = ref.substring(0, 2);
@@ -22,26 +22,22 @@ export function findCollection(ref = "") {
 export function postFixedLink(link) {
   return link
     .replace(/^<a href=([^ ]+)?.*$/i, "$1")
-    .replace(
-      /^<a href="(\/documentation\/memoire\/[^"]+)?.*$/i,
-      "http://www2.culture.gouv.fr$1"
-    );
+    .replace(/^<a href="(\/documentation\/memoire\/[^"]+)?.*$/i, "http://www2.culture.gouv.fr$1");
 }
 
 export function toFieldImages(images) {
   return images
+    .filter(i => i)
     .slice(0, 200)
     .map(e => {
       let source = e;
       let key = e;
       let link = "";
-
       if (e instanceof Object) {
         source = e.url;
         key = e.ref;
         link = `/notice/memoire/${e.ref}`;
       }
-
       if (!source.match(/^http/)) {
         source = `${bucket_url}${source}`;
       }
@@ -75,23 +71,9 @@ export function schema({
     return { "@type": "Person", name: name.trim() };
   });
   obj["comment"] = comment;
-
-  // obj["width"] = [
-  //   {
-  //     "@type": "Distance",
-  //     name: "55cm"
-  //   }
-  // ];
-  // obj["height"] = [
-  //   {
-  //     "@type": "Distance",
-  //     name: "42cm"
-  //   }
-  // ];
   obj["artMedium"] = artMedium;
   return JSON.stringify(obj);
 }
-
 
 export function hasCoordinates(point) {
   return !!(point && point.lat && point.lon);


### PR DESCRIPTION
La ligne importante c'est celle là : https://github.com/betagouv/pop/compare/ignore-null-on-image?expand=1#diff-8a1f8cb6500649b5c081c253aefd5c7eR30

ça fix le pb des notices mémoire qui n'ont pas d'images...

cf: https://sentry.data.gouv.fr/betagouvfr/popdatagouvfr/issues/657440/