### PR TITLE
polyfill for older browers

### DIFF
--- a/apps/diffusion/.babelrc.js
+++ b/apps/diffusion/.babelrc.js
@@ -8,12 +8,11 @@ module.exports = {
         "preset-env": {
           targets: {
             browsers: [">0.03%"]
-          }
+          },
+          useBuiltIns: "usage"
         }
       }
     ]
   ],
-  plugins: [
-    ["transform-define", env]
-  ]
+  plugins: [["transform-define", env]]
 };

--- a/apps/diffusion/package-lock.json
+++ b/apps/diffusion/package-lock.json
@@ -824,6 +824,16 @@
         "regexpu-core": "^4.1.3"
       }
     },
+    "@babel/polyfill": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
+      "integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.5.7",
+        "regenerator-runtime": "^0.12.0"
+      }
+    },
     "@babel/preset-env": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.3.1.tgz",

--- a/apps/diffusion/package.json
+++ b/apps/diffusion/package.json
@@ -48,6 +48,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.3.1",
     "@babel/plugin-transform-block-scoping": "^7.2.0",
     "@babel/plugin-transform-runtime": "^7.2.0",
+    "@babel/polyfill": "^7.2.5",
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-react": "^7.0.0",
     "babel-jest": "^24.0.0",


### PR DESCRIPTION
ça _devrait_ corriger une bonne partie des problèmes de navigateurs. Là en gros ça ajoute les polyfills qu'il faut dans chaque fichier : https://babeljs.io/docs/en/babel-polyfill#usage-in-node-browserify-webpack