### PR TITLE
fix multilist before advanced search

### DIFF
--- a/apps/diffusion/package-lock.json
+++ b/apps/diffusion/package-lock.json
@@ -7221,9 +7221,9 @@
       "integrity": "sha512-4NmSD7fMFlM8roNxs7YXPv7UFRbYzb0gufR5zBxJLRzY54+zFsavxBo6zsQzP9ep6Hh3pC2pTyrpSTBEaB6IkQ=="
     },
     "pop-shared": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/pop-shared/-/pop-shared-0.10.1.tgz",
-      "integrity": "sha512-HipZgzqLblJjA/rnwVaYeZ/BQmP37U1SrjUWQgEWbNTYmH2g73XgdihXhFBVirK7HKCcOPFHIqm8jgwHTxzOtQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/pop-shared/-/pop-shared-0.11.0.tgz",
+      "integrity": "sha512-M9ZPFiFWjPVMhvQQTogBRFAXs79899LYFXqyr/2nbWH80koCBs85fulsnOutVUwn88KEHk/9Joqvi1nCmwVZdA==",
       "requires": {
         "react-autocomplete": "^1.8.1"
       }

--- a/apps/diffusion/package.json
+++ b/apps/diffusion/package.json
@@ -14,7 +14,7 @@
     "next": "^7.0.2",
     "next-nprogress": "^1.4.0",
     "ngeohash": "^0.6.3",
-    "pop-shared": "^0.10.1",
+    "pop-shared": "^0.11.0",
     "query-string": "^5.1.1",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",

--- a/apps/diffusion/pages/search.js
+++ b/apps/diffusion/pages/search.js
@@ -2,17 +2,14 @@ import Router from "next/router";
 import Head from "next/head";
 import { Row, Col, Container } from "reactstrap";
 import { ReactiveBase } from "@appbaseio/reactivesearch";
-
 import Layout from "../src/components/Layout";
-
 import Header from "../src/search/Header";
 import Menu from "../src/search/Menu";
 import MobileFilters from "../src/search/MobileFilters";
-
 import Results from "../src/search/Results";
 import Search from "../src/search/Search";
-
 import { es_url } from "../src/config";
+import queryString from "query-string";
 
 const BASES = ["merimee", "palissy", "memoire", "joconde", "mnr"].join(",");
 
@@ -21,8 +18,13 @@ import "./search.css";
 export default class extends React.Component {
   state = { mobile_menu: false };
 
-  static async getInitialProps({ asPath, query: { view, mode } }) {
-    return { asPath, view: view || "list", mode };
+  static async getInitialProps({ asPath, query }) {
+    return {
+      asPath,
+      queryString: queryString.stringify(query),
+      view: query.view || "list",
+      mode: query.mode
+    };
   }
 
   componentDidMount() {
@@ -52,7 +54,7 @@ export default class extends React.Component {
               <Row className="search-row">
                 {this.props.mode === "simple" ? (
                   <Menu
-                    location={this.props.asPath}
+                    location={this.props.queryString}
                     mobile_menu={this.state.mobile_menu}
                     closeMenu={() => this.setState({ mobile_menu: false })}
                     view={this.props.view}

--- a/apps/diffusion/src/search/Menu.js
+++ b/apps/diffusion/src/search/Menu.js
@@ -1,7 +1,5 @@
 import React from "react";
-
 import { SelectedFilters } from "@appbaseio/reactivesearch";
-
 import { MultiList } from "pop-shared";
 
 const DEFAULT_FILTER = [
@@ -85,7 +83,6 @@ const Menu = ({ location, mobile_menu, closeMenu, view }) => (
         componentId="image"
         placeholder="oui ou non"
         showSearch={false}
-        // defaultSelected={view === "mosaic" ? ["oui"] : []}
         location={location}
       />
       <MultiList
@@ -97,7 +94,6 @@ const Menu = ({ location, mobile_menu, closeMenu, view }) => (
         className="filters"
         showSearch={false}
         URLParams={true}
-        // defaultSelected={view === "map" ? ["oui"] : []}
         data={[{ label: "oui", value: "oui" }, { label: "non", value: "non" }]}
         location={location}
       />

--- a/apps/diffusion/src/search/Search/index.js
+++ b/apps/diffusion/src/search/Search/index.js
@@ -1,7 +1,5 @@
 import React from "react";
 import Link from "next/link";
-import queryString from "query-string";
-
 import TextSearch from "./Search";
 import AdvancedSearch from "./SearchAdvanced";
 

--- a/apps/shared/example/src/App.js
+++ b/apps/shared/example/src/App.js
@@ -24,7 +24,6 @@ export default class App extends Component {
             queryFormat="or"
             className="filters"
             URLParams={true}
-            defaultSelected={["oui"]}
             data={[
               { label: "oui", value: "oui" },
               { label: "non", value: "non" }

--- a/apps/shared/package.json
+++ b/apps/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pop-shared",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "pop shared components",
   "author": "betagouv",
   "license": "MIT",

--- a/apps/shared/src/MultiList.js
+++ b/apps/shared/src/MultiList.js
@@ -6,10 +6,7 @@ import "./MultiList.css";
 import { toFrenchRegex } from "./utils";
 
 export default class MultiListUmbrellaUmbrella extends React.Component {
-  state = {
-    collapse: null
-  };
-
+  state = { collapse: null };
   urlLocation = null;
 
   onListClicked = () => {
@@ -18,38 +15,18 @@ export default class MultiListUmbrellaUmbrella extends React.Component {
 
   onCollapseChange = nextCollapseState => {
     this.setState({ collapse: nextCollapseState });
-    if (this.props.onCollapseChange) {
-      this.props.onCollapseChange(nextCollapseState, this.props.componentId);
-    }
   };
 
   componentWillMount() {
-    try {
-      if (location) {
-        this.urlLocation = location.search;
-      }
-    } catch (error) {
-      if (this.props.location) {
-        // If window.location not defined use props
-        this.urlLocation = this.props.location.search;
-      } else {
-        throw new Error("location is not defined");
-      }
+    if (this.props.location) {
+      this.urlLocation = this.props.location;
+    } else {
+      this.urlLocation = location.search;
     }
   }
 
   componentDidMount() {
     this.onCollapseChange(this.shouldCollapse());
-  }
-
-  componentDidUpdate(prevProps) {
-    if (prevProps.defaultSelected !== this.props.defaultSelected) {
-      if (this.props.defaultSelected && this.props.defaultSelected.length > 0) {
-        this.onCollapseChange(false);
-      } else if (!this.state.collapse) {
-        this.onCollapseChange(true);
-      }
-    }
   }
 
   shouldCollapse = () => {
@@ -61,10 +38,7 @@ export default class MultiListUmbrellaUmbrella extends React.Component {
 
   render() {
     const style = this.props.show === false ? { display: "none" } : {};
-    const collapse =
-      this.state.collapse === null
-        ? this.shouldCollapse()
-        : this.state.collapse;
+    const collapse = this.state.collapse === null ? this.shouldCollapse() : this.state.collapse;
     return (
       <div className="multilist" style={style}>
         <div className="topBar" onClick={this.onListClicked}>
@@ -85,7 +59,6 @@ export default class MultiListUmbrellaUmbrella extends React.Component {
                 displayCount={this.props.displayCount}
                 renderListItem={this.props.renderListItem}
                 filterListItem={this.props.filterListItem}
-                defaultSelected={this.props.defaultSelected}
                 dataField={this.props.dataField}
                 componentId={this.props.componentId}
                 sortByName={this.props.sortByName}
@@ -111,7 +84,7 @@ class MultiListUmbrella extends React.Component {
   }
 
   componentDidMount() {
-    const { location, componentId, defaultSelected } = this.props;
+    const { location, componentId } = this.props;
     this.updateInternalQuery("");
     const values = queryString.parse(location);
     const field = componentId;
@@ -121,30 +94,13 @@ class MultiListUmbrella extends React.Component {
         this.updateExternalQuery(selected);
         this.setState({ selected });
       } catch (e) {}
-    } else if (defaultSelected) {
-      const selected = defaultSelected;
-      this.updateExternalQuery(selected);
-      this.setState({ selected });
     }
   }
   componentWillReceiveProps(nextProps) {
     //get from url
-    if (
-      nextProps.selectedValue === null &&
-      this.props.selectedValue !== nextProps.selectedValue
-    ) {
+    if (nextProps.selectedValue === null && this.props.selectedValue !== nextProps.selectedValue) {
       const selected = [];
       this.setState({ selected });
-      this.updateExternalQuery(selected);
-    }
-
-    //default selected
-    if (
-      nextProps.defaultSelected &&
-      this.props.defaultSelected !== nextProps.defaultSelected
-    ) {
-      const selected = nextProps.defaultSelected;
-      // this.setState({ selected });
       this.updateExternalQuery(selected);
     }
   }
@@ -254,15 +210,10 @@ class MultiList extends React.Component {
         }
       }
     }
-    return this.props.displayCount
-      ? `${label} (${item.doc_count})`
-      : `${label} `;
+    return this.props.displayCount ? `${label} (${item.doc_count})` : `${label} `;
   }
   renderSuggestion() {
-    if (
-      this.props.aggregations &&
-      Object.keys(this.props.aggregations).length
-    ) {
+    if (this.props.aggregations && Object.keys(this.props.aggregations).length) {
       // Flat buckets (it may contain more than one aggregation)
       const aggs = this.props.aggregations;
       let buckets = [].concat.apply(


### PR DESCRIPTION
J’ai compris pourquoi ça fonctionnait mal côté recherche simple : en résumé on passait la chaine `search/mosaic/?image=["oui"]` au lieu de `?image=["oui"]` dans le paramètre “location”. Ça m’a fait détecter aussi pas mal de code mort et qui générait des boucles dans les components will update qui ne servaient à rien.

C'est une première étape qui devrait permettre de corriger le système des URL sur la recherche avancée !

Pour plus tard : il faudrait renommer `urlLocation` dans le multiList sui est SUPER mal nommé depuis le départ et qui m'a induit en erreur tout le long mais bon, une chose à la fois :) 