### PR TITLE
fix export

### DIFF
--- a/apps/production/src/scenes/search/components/export.js
+++ b/apps/production/src/scenes/search/components/export.js
@@ -3,8 +3,8 @@ import qs from "qs";
 import { ReactiveComponent } from "@appbaseio/reactivesearch";
 import { Button } from "reactstrap";
 import { QueryBuilder } from "pop-shared";
-import { history } from "../../../redux/store";
 import fetch from "isomorphic-fetch";
+import { history } from "../../../redux/store";
 import { es_url } from "../../../config";
 
 export default class ExportComponent extends React.Component {

--- a/apps/production/src/scenes/search/components/export.js
+++ b/apps/production/src/scenes/search/components/export.js
@@ -69,7 +69,8 @@ export default class ExportComponent extends React.Component {
       <ReactiveComponent
         componentId="export"
         react={{ and: this.props.FILTER }}
-        onQueryChange={async (_prev, next) => this.onChange(next)}
+        defaultQuery={() => ({ aggs: {} })}
+        onQueryChange={async (prev, next) => !prev && this.onChange(next)}
       >
         <Loading />
       </ReactiveComponent>


### PR DESCRIPTION
Selon moi c'est acceptable. Ce qui change **en négatif** : 
 - on a moins d'infos dans le chargement (juste un spinner qui tourne, mais c'est beaucoup plus rapide)
 - on ne peut plus exporter que 5000 notices, pour éviter de crasher le truc en staging (je ne sais pas pour la prod

Le reste est **positif**

D'après mon pote d'Algolia (il s'appelle Vincent comme ça je vais arrêter de l'appeler comme ça), c'est normal, c'est la bonne pratique de faire un onQueryChange comme j'ai fait pour un export... Bon OK, pas sûr qu'il ait tout compris though.