### PR TITLE
add info multi museo

### DIFF
--- a/apps/production/src/components/Tags/index.js
+++ b/apps/production/src/components/Tags/index.js
@@ -47,6 +47,7 @@ class index extends Component {
           autocomplete={0}
           autofocus={false}
         />
+        <small className="text-muted">Appuyez sur « entrée » pour ajouter un nouveau code Muséo</small>
       </div>
     );
   }

--- a/apps/production/src/scenes/admin/createUser.js
+++ b/apps/production/src/scenes/admin/createUser.js
@@ -70,6 +70,7 @@ class CreateUser extends React.Component {
             this.setState({ taginput });
           }}
         />
+         <small className="text-muted">Appuyez sur « entrée » pour ajouter un nouveau code Muséo</small>
       </div>
     );
   }


### PR DESCRIPTION
See : https://trello.com/c/5cxrXgFO/573-signaler-la-possibilite-davoir-plusieurs-codes-museo

J'ai pris la solution la moins chère pour pas alourdir (vu que c'est la lib https://www.npmjs.com/package/react-tag-input et que j'ai pas envie de la tordre) : 

<img width="452" alt="Capture d’écran 2019-03-29 à 10 22 47" src="https://user-images.githubusercontent.com/1575946/55222662-c46be000-520c-11e9-9c0a-6f9da454dcdd.png">
