### PR TITLE
fix upper case

### DIFF
--- a/apps/diffusion/__tests__/notices/Field.js
+++ b/apps/diffusion/__tests__/notices/Field.js
@@ -5,9 +5,9 @@ import Field from '../../src/notices/Field';
 describe('Field suite', () => {
   
   it('should render a p with title and content', () => {
-    const hello = shallow(<Field title="hello" content="mycontent" />);
+    const hello = shallow(<Field title="hello" content="Mycontent" />);
     expect(hello.find('#hello')).toHaveLength(1);
     expect(hello.find('#hello').text()).toContain('hello');
-    expect(hello.find('#hello>p').text()).toContain('mycontent');
+    expect(hello.find('#hello>p').text()).toContain('Mycontent');
   });
 });

--- a/apps/diffusion/src/notices/Field.js
+++ b/apps/diffusion/src/notices/Field.js
@@ -1,13 +1,20 @@
 import * as React from "react";
 
 export default ({ content, title, separator, join = ", " }) => {
-  if (!content || (Array.isArray(content) && content.length === 0)) {
+  // Don't render empty elements.
+  const isEmptyArray = c => Array.isArray(c) && c.length === 0;
+  const isEmptyString = s => typeof s === "string" && !s.trim();
+  if (!content || isEmptyArray(content) || isEmptyString(content)) {
     return null;
   }
 
+  // Transform array to string, by joining with a character.
   let str = Array.isArray(content) ? content.join(join) : content;
+
+  // Don't apply transformations on React components
   if (!React.isValidElement(str)) {
-    str = str.replace(/\u0092/g, `'`);
+    // Fix simple quotes and capitalize first letter (only if it's a string)
+    str = str.replace(/\u0092/g, `'`).replace(/^./, str => str.toUpperCase());
     if (separator) {
       str = replaceAll(str, separator, "\n");
     }
@@ -29,10 +36,6 @@ export default ({ content, title, separator, join = ", " }) => {
           white-space: pre-line;
           margin-bottom: 15px;
           text-align: justify;
-        }
-
-        .field p::first-letter {
-          text-transform: capitalize;
         }
 
         .field h3 {


### PR DESCRIPTION
Ce fix corrige trois trucs : 

 - On ne pouvait pas sélectionner la dernière lettre des notices (à cause d'un bug des nevigateurs avec la capitalization en CSS) https://trello.com/c/HrGtimZ2/391-copier-dans-la-diffusion-ne-s%C3%A9lectionne-pas-la-derni%C3%A8re-lettre
- Les URL et autres éléments React étaient mis en majuscules ce qui faisait bizarre
- Des fois "Mots-clés" (ou autre) s'affichait alors que c'était vide, maintenant ce n'est plus le cas