### PR TITLE
react elasticsearch import list

### DIFF
--- a/apps/production/src/scenes/import/list.css
+++ b/apps/production/src/scenes/import/list.css
@@ -4,15 +4,18 @@
   padding: 18px;
 }
 
-.list-import .filter{
+.list-import .filter {
   background-color: white;
   padding: 20px;
   margin-top: 10px;
   border-radius: 5px;
   box-shadow: 1px 2px 2px 0 rgba(197, 197, 197, 0.5);
 }
-
-.list-import .reactive-list > div {
+.list-import .react-es-results > div:nth-child(1),
+.list-import .react-es-pagination {
+  flex: 0 0 100%;
+}
+.list-import .react-es-results {
   display: flex;
   flex-wrap: wrap;
   margin-right: -15px;

--- a/apps/production/src/scenes/import/list.js
+++ b/apps/production/src/scenes/import/list.js
@@ -1,94 +1,93 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import {
-  ReactiveBase,
-  DataSearch,
-  ReactiveList,
-  SelectedFilters,
-  MultiList
-} from "@appbaseio/reactivesearch/lib";
+  Elasticsearch,
+  SearchBox,
+  Results,
+  toUrlQueryString,
+  fromUrlQueryString,
+  ActiveFilters
+} from "react-elasticsearch";
 import { Row, Col } from "reactstrap";
-
+import CollapsableFacet from "../search/components/CollapsableFacet";
 import utils from "./utils.js";
-
 import "./list.css";
-
 import { es_url } from "../../config.js";
 
-const FILTER = ["mainSearch", "institution", "email", "notices"];
+export default function List() {
+  const initialValues = fromUrlQueryString(window.location.search.replace(/^\?/, ""));
+  const sortKey = "importedAt";
+  const [sortOrder, setSortOrder] = useState(initialValues.get("sortOrder") || "desc");
+  const [sortQuery, setSortQuery] = useState([{ [sortKey]: { order: sortOrder } }]);
 
-export default class List extends React.Component {
-  render() {
-    return (
-      <div className="list-import">
-        <ReactiveBase url={`${es_url}/import`} app="import">
-          <Row>
-            <Col md="3">
-              <DataSearch
-                className="filter"
-                componentId="mainSearch"
-                dataField={["institution", "email", "notices"]}
-                queryFormat="and"
-                iconPosition="left"
-                title="Recherche"
-                className="mainSearch"
-                placeholder="Saisissez une notice, une adresse email ou une institution"
-                URLParams={true}
-              />
-              <MultiList
-                className="filter"
-                componentId="institution"
-                dataField="institution.keyword"
-                title="Institutions"
-                placeholder="Sélectionnez une institution"
-                react={{ and: FILTER.filter(e => e !== "institution") }}
-              />
-              <MultiList
-                className="filter"
-                componentId="email"
-                dataField="email.keyword"
-                title="Email"
-                placeholder="Sélectionnez un email"
-                react={{ and: FILTER.filter(e => e !== "email") }}
-              />
-              <MultiList
-                className="filter"
-                componentId="notices"
-                dataField="notices.keyword"
-                title="Notices"
-                placeholder="Sélectionnez une notice"
-                react={{ and: FILTER.filter(e => e !== "notices") }}
-              />
-            </Col>
-            <Col md="9">
-              <SelectedFilters clearAllLabel="Tout supprimer" />
-              <ReactiveList
-                sortOptions={[
-                  { label: "Les plus récents en premier", dataField: "importedAt", sortBy: "desc" },
-                  { label: "Les plus anciens en premier", dataField: "importedAt", sortBy: "asc" }
-                ]}
-                componentId="results"
-                className="reactive-list"
-                react={{ and: FILTER }}
-                onResultStats={(total, took) => {
-                  if (total === 1) {
-                    return `1 résultat`;
-                  }
-                  return `${total} résultats`;
-                }}
-                onNoResults="Aucun résultat trouvé."
-                loader="Préparation de l'affichage des résultats..."
-                dataField="yo"
-                URLParams={true}
-                size={20}
-                onData={data => <Card key={data.REF} data={data} />}
-                pagination={true}
-              />
-            </Col>
-          </Row>
-        </ReactiveBase>
-      </div>
-    );
-  }
+  useEffect(() => {
+    setSortQuery([{ [sortKey]: { order: sortOrder } }]);
+  }, [sortKey, sortOrder]);
+  return (
+    <div className="list-import">
+      <Elasticsearch
+        url={`${es_url}/import`}
+        onChange={params => {
+          const q = toUrlQueryString(params);
+          if (q) {
+            window.history.replaceState("x", "y", `?${q}`);
+          }
+        }}
+      >
+        <Row>
+          <Col md="3">
+            <SearchBox
+              id="main"
+              placeholder="Saisissez une notice, une adresse email ou une institution"
+              initialValue={initialValues.get("main")}
+              fields={["institution", "email", "notices"]}
+            />
+            <ActiveFilters id="af" />
+            <CollapsableFacet
+              id="institution"
+              initialValue={initialValues.get("institution")}
+              fields={["institution.keyword"]}
+              title="Institutions"
+            />
+            <CollapsableFacet
+              id="email"
+              initialValue={initialValues.get("email")}
+              fields={["email.keyword"]}
+              title="Email"
+            />
+            <CollapsableFacet
+              id="notices"
+              initialValue={initialValues.get("notices")}
+              fields={["notices.keyword"]}
+              title="Notices"
+            />
+          </Col>
+          <Col md="9">
+            <Results
+              sort={sortQuery}
+              initialPage={initialValues.get("resPage")}
+              id="res"
+              itemsPerPage={20}
+              item={(source, _score, id) => <Card key={id} data={source} />}
+              pagination={utils.pagination}
+              stats={total => (
+                <div>
+                  {total} résultat{total === 1 ? "" : "s"}
+                  <select
+                    className="ml-2"
+                    onChange={e => setSortOrder(e.target.value)}
+                    value={sortOrder}
+                  >
+                    <option value="desc">Les plus récents en premier</option>
+                    <option value="asc">Les plus anciens en premier</option>
+                  </select>
+                </div>
+              )}
+            />
+          </Col>
+        </Row>
+      </Elasticsearch>
+    </div>
+  );
 }
 
 const Card = ({ data }) => {


### PR DESCRIPTION
Actuellement la lib reactivesearch fait ~550k et react-elasticsearch ~120k (non compressées) dans la production. Les deux cohabitent, alors qu'on pourrait virer reactivesearch.

Mais pour cela il faut virer les endroits où c'est utlisé. Il reste les imports et les galleries, voilà déjà les imports.

Après tout ça je pourrais nettoyer des kilomètres de CSS et enlever 550K à notre bundle.