### PR TITLE
fix sentry pollution

### DIFF
--- a/apps/production/src/services/request.js
+++ b/apps/production/src/services/request.js
@@ -70,8 +70,17 @@ class request {
             resolve(res);
             return;
           }
-          Raven.captureException(JSON.stringify(err));
-          reject("Problème lors de la récupération de la donnée", err);
+          // Special case: we don't want to track unsuccessful login, 
+          // nor anything about "unauthorized". So there is a `reject`
+          // operation, but no Raven.capture.
+          // See: https://sentry.data.gouv.fr/betagouvfr/pop-culture/issues/644727/
+          if (res.success === false && res.msg && response.status === 401) {
+            reject(res.msg);
+            return;
+          }
+          // Stringify response and send it to Sentry.
+          Raven.captureException(JSON.stringify(res));
+          reject("Problème lors de la récupération de la donnée", res);
         } catch (err) {
           Raven.captureException(JSON.stringify(err));
           reject("Problème lors de la récupération de la donnée", err);


### PR DESCRIPTION
Notre bug principal sur Sentry est lié aux connexions échouées. Cette correction fixe trois trucs : 
 - On en reçoit plus d'erreur dans Sentry quand la connexion échoue. \o/
 - On affiche maintenant le VRAI message d'erreur (login ou mot de passe incorrect par exemple, plut^to que PB dans l'API).
 - Dans Sentry, si on a quand même une erreur autre (genre une 500) on aura tout le contenu de la réponse

Voir : https://sentry.data.gouv.fr/betagouvfr/pop-culture/issues/644727/

Et voir les commaentaires dans le code