### PR TITLE
fix museo bug

### DIFF
--- a/apps/diffusion/pages/museo.js
+++ b/apps/diffusion/pages/museo.js
@@ -80,7 +80,7 @@ export default class extends React.Component {
         return (
           <React.Fragment key={key}>
             <dt>{this.label(key)}</dt>
-            <dd>{this.text(key, val)}</dd>
+            <dd>{this.text(key, Array.isArray(val) ? val.join("#") : val )}</dd>
           </React.Fragment>
         );
       });

--- a/apps/diffusion/pages/museo.js
+++ b/apps/diffusion/pages/museo.js
@@ -48,11 +48,11 @@ export default class extends React.Component {
           {val}
         </a>
       );
-    } else if (val.match(/#/)) {
-      const list = val
-        .split("#")
-        .filter(v => v)
-        .map((v, i) => <li key={i}>{this.removeUglyChars(v)}</li>);
+    } else if (val.match(/#/) || Array.isArray(val)) {
+      if (!Array.isArray(val)) {
+        val = val.split("#");
+      }
+      const list = val.filter(v => v).map((v, i) => <li key={i}>{this.removeUglyChars(v)}</li>);
       return <ul>{list}</ul>;
     }
     return this.removeUglyChars(val);
@@ -80,7 +80,7 @@ export default class extends React.Component {
         return (
           <React.Fragment key={key}>
             <dt>{this.label(key)}</dt>
-            <dd>{this.text(key, Array.isArray(val) ? val.join("#") : val )}</dd>
+            <dd>{this.text(key, val)}</dd>
           </React.Fragment>
         );
       });


### PR DESCRIPTION
À l'époque où j'ai fait les imports, il n'y avait que des chaines de caractères en base. Donc ça buguait avec des tableaux. C'était une des erreurs qu'on avait le plus dans Sentry, maitenant c'est fixé. Pour la bidouille : les fonctions splittaient déjà sur #, car c'est ce qui est utilisé en interne par MUSEOFILE. Pour moi _ça passe_.

VOir : https://sentry.data.gouv.fr/betagouvfr/pop-culture/issues/642074/activity/