### PR TITLE
new api usage in production step 1

### DIFF
--- a/apps/production/src/scenes/notice/autor.js
+++ b/apps/production/src/scenes/notice/autor.js
@@ -38,19 +38,12 @@ class Autor extends React.Component {
       return;
     }
     this.props.initialize(notice);
-    const editable = this.props.canUpdate && this.props.user.role === "administrateur";
+    const editable = false;
     this.setState({ loading: false, notice, editable });
   }
 
-  async onSubmit(values) {
-    this.setState({ saving: true });
-    const notice = await API.updateNotice(this.state.notice.REF, "autor", values);
-    toastr.success(
-      "Modification enregistrée",
-      "La modification sera visible dans 1 à 5 min en diffusion"
-    );
-    this.setState({ saving: false, notice });
-  }
+  // Not implemented yet (not editable)
+  async onSubmit() {}
 
   render() {
     if (this.state.loading) {
@@ -147,9 +140,7 @@ const CustomField = ({ name, disabled, ...rest }) => {
 
 const mapStateToProps = ({ Auth }) => {
   const { role, group } = Auth.user;
-  const canUpdate = false;
   return {
-    canUpdate,
     user: { role, group }
   };
 };

--- a/apps/production/src/scenes/notice/joconde.js
+++ b/apps/production/src/scenes/notice/joconde.js
@@ -58,15 +58,18 @@ class Notice extends React.Component {
     });
   }
 
-  onSubmit(values) {
+  async onSubmit(values) {
     this.setState({ saving: true });
-    API.updateNotice(this.state.notice.REF, "joconde", values, this.state.imagesFiles).then(e => {
+    try {
+      await API.updateNotice(this.state.notice.REF, "joconde", values, this.state.imagesFiles);
       toastr.success(
         "Modification enregistrée",
-        "La modification sera visible dans 1 à 5 min en diffusion"
+        "La modification sera visible dans 1 à 5 min en diffusion."
       );
-      this.setState({ saving: false });
-    });
+    } catch (e) {
+      toastr.error("La modification n'a pas été enregistrée", (e.msg || ""));
+    }
+    this.setState({ saving: false });
   }
 
   render() {

--- a/apps/production/src/scenes/notice/memoire.js
+++ b/apps/production/src/scenes/notice/memoire.js
@@ -73,11 +73,15 @@ class Notice extends React.Component {
 
   async onSubmit(values) {
     this.setState({ saving: true });
-    await API.updateNotice(this.state.notice.REF, "memoire", values, this.state.imagesFiles);
-    toastr.success(
-      "Modification enregistrée",
-      "La modification sera visible dans 1 à 5 min en diffusion"
-    );
+    try {
+      await API.updateNotice(this.state.notice.REF, "memoire", values, this.state.imagesFiles);
+      toastr.success(
+        "Modification enregistrée",
+        "La modification sera visible dans 1 à 5 min en diffusion."
+      );
+    } catch (e) {
+      toastr.error("La modification n'a pas été enregistrée", (e.msg || ""));
+    }
     this.setState({ saving: false });
   }
 

--- a/apps/production/src/scenes/notice/merimee.js
+++ b/apps/production/src/scenes/notice/merimee.js
@@ -68,11 +68,15 @@ class Notice extends React.Component {
 
   async onSubmit(values) {
     this.setState({ saving: true });
-    await API.updateNotice(this.state.notice.REF, "merimee", values);
-    toastr.success(
-      "Modification enregistrée",
-      "La modification sera visible dans 1 à 5 min en diffusion"
-    );
+    try {
+      await API.updateNotice(this.state.notice.REF, "merimee", values);
+      toastr.success(
+        "Modification enregistrée",
+        "La modification sera visible dans 1 à 5 min en diffusion."
+      );
+    } catch (e) {
+      toastr.error("La modification n'a pas été enregistrée", (e.msg || ""));
+    }
     this.setState({ saving: false });
   }
 

--- a/apps/production/src/scenes/notice/mnr.js
+++ b/apps/production/src/scenes/notice/mnr.js
@@ -63,13 +63,12 @@ class Notice extends React.Component {
       await API.updateNotice(this.state.notice.REF, "mnr", values, this.state.imagesFiles);
       toastr.success(
         "Modification enregistrée",
-        "La modification sera visible dans 1 à 5 min en diffusion"
+        "La modification sera visible dans 1 à 5 min en diffusion."
       );
-      this.setState({ saving: false });
     } catch (e) {
-      toastr.error("Impossible d'enregistrer la modification. Error", JSON.stringify(e));
-      this.setState({ saving: false });
+      toastr.error("La modification n'a pas été enregistrée", (e.msg || ""));
     }
+    this.setState({ saving: false });
   }
 
   render() {

--- a/apps/production/src/scenes/notice/museo.js
+++ b/apps/production/src/scenes/notice/museo.js
@@ -55,17 +55,16 @@ class Museo extends React.Component {
 
   async onSubmit(values) {
     this.setState({ saving: true });
-    const notice = await API.updateNotice(
-      this.state.notice.REF,
-      "museo",
-      values,
-      this.state.imagesFiles
-    );
-    toastr.success(
-      "Modification enregistrée",
-      "La modification sera visible dans 1 à 5 min en diffusion"
-    );
-    this.setState({ saving: false, notice });
+    try {
+      await API.updateNotice(this.state.notice.REF, "museo", values, this.state.imagesFiles);
+      toastr.success(
+        "Modification enregistrée",
+        "La modification sera visible dans 1 à 5 min en diffusion."
+      );
+    } catch (e) {
+      toastr.error("La modification n'a pas été enregistrée", (e.msg || ""));
+    }
+    this.setState({ saving: false });
   }
 
   render() {

--- a/apps/production/src/scenes/notice/palissy.js
+++ b/apps/production/src/scenes/notice/palissy.js
@@ -64,17 +64,18 @@ class Notice extends React.Component {
     return false;
   }
 
-  onSubmit(values) {
+  async onSubmit(values) {
     this.setState({ saving: true });
-
-    console.log("VALUES", values);
-    API.updateNotice(this.state.notice.REF, "palissy", values).then(e => {
+    try {
+      await API.updateNotice(this.state.notice.REF, "palissy", values);
       toastr.success(
         "Modification enregistrée",
-        "La modification sera visible dans 1 à 5 min en diffusion"
+        "La modification sera visible dans 1 à 5 min en diffusion."
       );
-      this.setState({ saving: false });
-    });
+    } catch (e) {
+      toastr.error("La modification n'a pas été enregistrée", (e.msg || ""));
+    }
+    this.setState({ saving: false });
   }
 
   render() {


### PR DESCRIPTION
Je préfère faire pas à pas (déjà pour voir si tu es OK avec le chemin que je prends). Donc là j'ai mis à jour juste `updateNotice` pour que ça fonctionne avec les bons retours. Par exemple, avec les contrôles on pourra renvoyer des messages précis depuis l'API (en renvoyant 400 avec un msg).

La partie sur les import en bulk, je sais pas comment la traiter encore, je pense que j'y verrai plus clair quand j'aurai traité tout le reste. Donc je lui ai laissé son vieux fonctionnement (d'où le `legacyUpdateNotice` temporaire que j'ai mis le temps de m'y attaquer).

Toute cette partie est un GROS refacto de tous les appels API et les traitements derrière donc ça va couter du temps (1 jour si je suis bien concentré en mode tunnel). D'où le fait que je fais juste une première PR ici.

En bonus : author n'était pas éditable du tout alors j'ai fait comme pour enluminures et les autres concernés, j'ai enlevé le save.