### PR TITLE
exclude restricted fields from ES indexing

### DIFF
--- a/apps/api/src/elasticsearch/sync.js
+++ b/apps/api/src/elasticsearch/sync.js
@@ -128,7 +128,8 @@ async function run() {
                   let notices = await noticeClass
                     .find(lastId ? { _id: { $gt: lastId } } : {})
                     .sort({ _id: 1 })
-                    .limit(opts.chunks);
+                    .limit(opts.chunks)
+                    .select("-ADRS2 -COM2 -EDIF2 -EMPL2 -INSEE2 -LBASE2");
                   if (!notices.length) {
                     ctx.error = false;
                     observer.complete();


### PR DESCRIPTION
👋 Hello ! Je travaille sur [Collectif Objets](https://collectif-objets.beta.gouv.fr/) et on s'intéresse pas mal aux données de POP.

Je vous propose ce changement pour ne plus indexer les champs de Palissy qui ne devraient pas être exposés par l'API ElasticSearch. Pour l'instant ils sont uniquement [exclus côté client](https://github.com/betagouv/pop/commit/c19a9b0e8ed8091c0498e45e612fcc80132edd2a), ce qui est facilement contournable.

⚠️ je n'ai pas pu tester ce changement puisque je n'ai pas l'accès à la DB source de POP. 